### PR TITLE
name_id length aligned to id field of name table

### DIFF
--- a/src/migrations/2013_11_28_170817_create_geonames_alternate_names_table.php
+++ b/src/migrations/2013_11_28_170817_create_geonames_alternate_names_table.php
@@ -15,7 +15,7 @@ class CreateGeonamesAlternateNamesTable extends Migration {
 		Schema::create('geonames_alternate_names', function(Blueprint $table)
 		{
 			$table->increments('id');
-			$table->integer('name_id')->index();
+			$table->integer('name_id')->->unsigned()->index();
 			$table->string('iso_language', 7);
 			$table->string('alternate_name', 200);
 			$table->boolean('is_preferred')->index();

--- a/src/migrations/2013_11_28_170817_create_geonames_alternate_names_table.php
+++ b/src/migrations/2013_11_28_170817_create_geonames_alternate_names_table.php
@@ -15,7 +15,7 @@ class CreateGeonamesAlternateNamesTable extends Migration {
 		Schema::create('geonames_alternate_names', function(Blueprint $table)
 		{
 			$table->increments('id');
-			$table->integer('name_id')->->unsigned()->index();
+			$table->integer('name_id')->unsigned()->index();
 			$table->string('iso_language', 7);
 			$table->string('alternate_name', 200);
 			$table->boolean('is_preferred')->index();


### PR DESCRIPTION
Current migration file creates an INT(11) for name_id field in alternate_names table.
This field is the "natural" foreign key  pointing to the id of names in geonames_name table but this ID field is an INT(10).
So, creation of a Foreign KEY is not possible.
In migration of alternate_names table the name_id field should be an unsigned in order to obtain an iNT(10).
